### PR TITLE
Add `before_send_service` support in Laravel provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@
 
 Laravel error catcher for [Hawk.so](https://hawk.so).
 
-> **Note:** This project is currently in the testing phase and may change in the future.
+## Setup
 
 ---
-
-## Setup
 
 1. [Register](https://garage.hawk.so/sign-up) an account, create a project, and get an **Integration Token**.
 2. Install the SDK via [Composer](https://getcomposer.org):
@@ -24,9 +22,22 @@ Laravel error catcher for [Hawk.so](https://hawk.so).
 - PHP **7.2+**
 - Laravel **11.x+**
 
+## Features
+
 ---
 
+- 🦅 Automatic error catching
+- 💎 Manual exception and message sending
+- 🙂 Attaching user information
+- 📦 Attaching additional context
+- 🛡️ Sensitive data filtering
+- 🌟 BeforeSend hook for event preprocessing
+- 🗂️ Breadcrumbs collection (routes, queries, jobs, logs)
+- ⚡ Laravel 11+ support
+
 ## Configuration
+
+---
 
 ### Enable exception capturing
 
@@ -80,9 +91,9 @@ Then add your token in `.env`:
 HAWK_TOKEN=<your_integration_token>
 ```
 
----
-
 ## Usage
+
+---
 
 ### Adding User & Context Information
 
@@ -137,9 +148,9 @@ app(\HawkBundle\Catcher::class)->sendMessage(
 );
 ```
 
----
-
 ## BeforeSend Hook
+
+---
 
 If you want to modify or filter errors before they are sent to Hawk,  
 implement the `BeforeSendServiceInterface`.
@@ -185,23 +196,23 @@ return [
 ];
 ```
 
----
-
 ## Issues & Contributions
+
+---
 
 - Found a bug? [Open an issue](https://github.com/codex-team/hawk.laravel/issues)
 - Want to improve the package? Pull requests are welcome!
 
----
-
 ## Useful Links
+
+---
 
 - **Repository:** [github.com/codex-team/hawk.laravel](https://github.com/codex-team/hawk.laravel)
 - **Composer Package:** [packagist.org/packages/codex-team/hawk.laravel](https://packagist.org/packages/codex-team/hawk.laravel)
 - **CodeX Team:** [codex.so](https://codex.so)
 
----
-
 ## License
+
+---
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
-**This project is currently in the testing phase and may undergo changes.**
-
 # Hawk Laravel
 
-Laravel errors Catcher for [Hawk.so](https://hawk.so).
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/codex-team/hawk.laravel.svg?style=flat-square)](https://packagist.org/packages/codex-team/hawk.laravel)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
+[![PHP Version](https://img.shields.io/packagist/php-v/codex-team/hawk.laravel?style=flat-square)](https://www.php.net/)
+
+Laravel error catcher for [Hawk.so](https://hawk.so).
+
+> **Note:** This project is currently in the testing phase and may change in the future.
+
+---
 
 ## Setup
 
-1. [Register](https://garage.hawk.so/sign-up) an account, create a Project and get an Integration Token.
+1. [Register](https://garage.hawk.so/sign-up) an account, create a project, and get an **Integration Token**.
+2. Install the SDK via [Composer](https://getcomposer.org):
 
-2. Install SDK via [composer](https://getcomposer.org) to install the Catcher
+   ```bash
+   composer require codex-team/hawk.laravel
+   ```
 
-- Catcher provides support for PHP 7.2 or later
-- Your Laravel version needs to be 11.x or higher
+### Requirements
 
-### Install command
+- PHP **7.2+**
+- Laravel **11.x+**
 
-```bash
-$ composer require codex-team/hawk.laravel
-```
+---
 
-To enable capturing unhandled exceptions for reporting to `Hawk`, modify your `bootstrap/app.php` file as follows:
+## Configuration
+
+### Enable exception capturing
+
+Update your `bootstrap/app.php`:
 
 ```php
 <?php
@@ -39,12 +50,13 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         HawkBundle\Integration::handles($exceptions);
-    })->create();
+    })
+    ->create();
 ```
 
 ### Register the Service Provider
 
-To complete the setup, add the `Hawk` service provider to your `config/app.php` or `bootstrap/providers.php` file in the providers array:
+Add the `Hawk` service provider to your `config/app.php` or `bootstrap/providers.php`:
 
 ```php
 'providers' => [
@@ -53,34 +65,143 @@ To complete the setup, add the `Hawk` service provider to your `config/app.php` 
 ],
 ```
 
-### Configuration
+### Publish configuration
 
-Set up Hawk using the following command:
+Run:
 
 ```bash
-$ php artisan hawkbundle:publish
+php artisan hawkbundle:publish
 ```
 
-This will create the configuration file (`config/hawk.php`), and you can manually add the `HAWK_TOKEN` in your `.env` file:
+This will create `config/hawk.php`.  
+Then add your token in `.env`:
 
 ```env
-HAWK_TOKEN=<your integration token>
+HAWK_TOKEN=<your_integration_token>
 ```
 
-## Issues and improvements
+---
 
-Feel free to ask questions or improve the project.
+## Usage
 
-## Links
+### Adding User & Context Information
 
-Repository: https://github.com/codex-team/hawk.laravel
+```php
+app(\HawkBundle\Catcher::class)->setUser([
+    'name' => 'John Doe',
+    'photo' => 'https://example.com/avatar.png',
+]);
 
-Report a bug: https://github.com/codex-team/hawk.laravel/issues
+app(\HawkBundle\Catcher::class)->setContext([
+    'page' => 'checkout',
+    'cart_id' => 123,
+]);
+```
 
-Composer Package: https://packagist.org/packages/codex-team/hawk.laravel
+### Sending Exceptions Manually
 
-CodeX Team: https://codex.so
+Inject `\HawkBundle\Catcher` and call `sendException`:
+
+```php
+use HawkBundle\Catcher;
+
+class TestController extends Controller
+{
+    private Catcher $catcher;
+
+    public function __construct(Catcher $catcher)
+    {
+        $this->catcher = $catcher;
+    }
+
+    public function test()
+    {
+        try {
+            // Code that may fail
+        } catch (\Exception $e) {
+            $this->catcher->sendException($e);
+        }
+    }
+}
+```
+
+### Sending Custom Messages
+
+```php
+app(\HawkBundle\Catcher::class)->sendMessage(
+    'Checkout started',
+    [
+        'cart_id' => 123,
+        'step' => 'payment',
+    ]
+);
+```
+
+---
+
+## BeforeSend Hook
+
+If you want to modify or filter errors before they are sent to Hawk,  
+implement the `BeforeSendServiceInterface`.
+
+Example:
+
+```php
+<?php
+
+namespace App\Hawk;
+
+use Hawk\EventPayload;
+use HawkBundle\Services\BeforeSendServiceInterface;
+
+class BeforeSendService implements BeforeSendServiceInterface
+{
+    public function __invoke(EventPayload $eventPayload): ?EventPayload
+    {
+        $user = $eventPayload->getUser();
+
+        // Remove sensitive data
+        if (!empty($user['email'])) {
+            unset($user['email']);
+            $eventPayload->setUser($user);
+        }
+
+        // Skip sending in specific cases
+        if ($eventPayload->getContext()['skip_sending'] ?? false) {
+            return null;
+        }
+
+        return $eventPayload;
+    }
+}
+```
+
+Register it in `config/hawk.php`:
+
+```php
+return [
+    'integration_token' => env('HAWK_TOKEN'),
+    'before_send_service' => \App\Hawk\BeforeSendService::class,
+];
+```
+
+---
+
+## Issues & Contributions
+
+- Found a bug? [Open an issue](https://github.com/codex-team/hawk.laravel/issues)
+- Want to improve the package? Pull requests are welcome!
+
+---
+
+## Useful Links
+
+- **Repository:** [github.com/codex-team/hawk.laravel](https://github.com/codex-team/hawk.laravel)
+- **Composer Package:** [packagist.org/packages/codex-team/hawk.laravel](https://packagist.org/packages/codex-team/hawk.laravel)
+- **CodeX Team:** [codex.so](https://codex.so)
+
+---
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Laravel errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher", "monolog", "laravel"],
     "type": "library",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "license": "MIT",
     "require": {
         "php": "^7.2 || ^8.0",

--- a/config/hawk.php
+++ b/config/hawk.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'integration_token' => env('HAWK_TOKEN', '')
+    'integration_token' => env('HAWK_TOKEN', ''),
+    'before_send_service' => null
 ];

--- a/src/ErrorLoggerServiceProvider.php
+++ b/src/ErrorLoggerServiceProvider.php
@@ -73,9 +73,9 @@ class ErrorLoggerServiceProvider extends ServiceProvider
                 }
 
                 $options['before_send'] = $app->make($beforeSendService);
-
-                return Catcher::init($options, $breadcrumbsCollector);
             }
+
+            return Catcher::init($options, $breadcrumbsCollector);
         });
 
         $this->app->singleton('Illuminate\Contracts\Debug\ExceptionHandler', function ($app) {

--- a/src/ErrorLoggerServiceProvider.php
+++ b/src/ErrorLoggerServiceProvider.php
@@ -6,6 +6,7 @@ namespace HawkBundle;
 
 use HawkBundle\Console\Commands\PublishHawkConfig;
 use HawkBundle\Handlers\ErrorHandler;
+use HawkBundle\Services\BeforeSendServiceInterface;
 use HawkBundle\Services\BreadcrumbsCollector;
 use HawkBundle\Services\DataFilter;
 use HawkBundle\Services\ErrorLoggerService;
@@ -16,6 +17,7 @@ use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Log\Events\MessageLogged;
+use InvalidArgumentException;
 
 class ErrorLoggerServiceProvider extends ServiceProvider
 {
@@ -49,9 +51,31 @@ class ErrorLoggerServiceProvider extends ServiceProvider
         $this->app->singleton(Catcher::class, function ($app) {
             $breadcrumbsCollector = $app->make(BreadcrumbsCollector::class);
 
-            return Catcher::init([
-                'integrationToken' => config('hawk.integration_token') ?: ''
-            ], $breadcrumbsCollector);
+            $options = [
+                'integrationToken' => config('hawk.integration_token') ?: '',
+            ];
+
+            $beforeSendService = config('hawk.before_send_service');
+            if (!empty($beforeSendService)) {
+                if (!class_exists($beforeSendService)) {
+                    throw new InvalidArgumentException(sprintf(
+                        'The before_send_service class "%s" does not exist.',
+                        $beforeSendService
+                    ));
+                }
+
+                if (!is_subclass_of($beforeSendService, BeforeSendServiceInterface::class)) {
+                    throw new InvalidArgumentException(sprintf(
+                        'The service "%s" must implement "%s".',
+                        $beforeSendService,
+                        BeforeSendServiceInterface::class
+                    ));
+                }
+
+                $options['before_send'] = $app->make($beforeSendService);
+
+                return Catcher::init($options, $breadcrumbsCollector);
+            }
         });
 
         $this->app->singleton('Illuminate\Contracts\Debug\ExceptionHandler', function ($app) {

--- a/src/Services/BeforeSendServiceInterface.php
+++ b/src/Services/BeforeSendServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HawkBundle\Services;
+
+interface BeforeSendServiceInterface
+{
+
+}

--- a/src/Services/BeforeSendServiceInterface.php
+++ b/src/Services/BeforeSendServiceInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace HawkBundle\Services;
 
+use Hawk\EventPayload;
+
 interface BeforeSendServiceInterface
 {
-
+    public function __invoke(EventPayload $eventPayload): ?EventPayload;
 }


### PR DESCRIPTION
### Summary
This PR introduces support for the `before_send_service` option in the Laravel integration.

### Why
This allows developers to preprocess, enrich or filter events before they are sent to Hawk, enabling more flexible error reporting (e.g., removing sensitive data, conditionally skipping events).