### PR TITLE
Remove redundant ExceptionHandler override for Laravel (#10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "Laravel errors Catcher module for Hawk.so",
     "keywords": ["hawk", "php", "error", "catcher", "monolog", "laravel"],
     "type": "library",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "license": "AGPL-3.0-only",
     "require": {
         "php": "^7.2 || ^8.0",
-        "codex-team/hawk.php": "^2.2.9",
+        "codex-team/hawk.php": "^2.2.10",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "guzzlehttp/psr7": "^2.1.1",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0"

--- a/src/ErrorLoggerServiceProvider.php
+++ b/src/ErrorLoggerServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace HawkBundle;
 
 use HawkBundle\Console\Commands\PublishHawkConfig;
-use HawkBundle\Handlers\ErrorHandler;
 use HawkBundle\Services\BeforeSendServiceInterface;
 use HawkBundle\Services\BreadcrumbsCollector;
 use HawkBundle\Services\DataFilter;
@@ -76,10 +75,6 @@ class ErrorLoggerServiceProvider extends ServiceProvider
             }
 
             return Catcher::init($options, $breadcrumbsCollector);
-        });
-
-        $this->app->singleton('Illuminate\Contracts\Debug\ExceptionHandler', function ($app) {
-            return new ErrorHandler($app, $app->make(ErrorLoggerService::class));
         });
 
         Event::listen(RouteMatched::class, function (RouteMatched $event) {


### PR DESCRIPTION
This PR removes the singleton binding of a custom ExceptionHandler in ErrorLoggerServiceProvider
for Laravel 11 and newer. The override is redundant because Laravel 11+ supports the reportable()
callback, and keeping it breaks middleware execution (e.g., CORS headers).

Resolves #10 